### PR TITLE
Fix sprite removal from layers

### DIFF
--- a/kandy_jump.ts
+++ b/kandy_jump.ts
@@ -148,9 +148,16 @@ class MainGame {
                     s.update();
                     nextSprites.push(s);
                 } else {
-                    // Seems like a complicated way to manage remove(s), but I
-                    // couldn't find anything simpler.
-                    s.layer = s.layer.filter((x: Sprite) => { return x != s; });
+                    // Remove sprite from its render layer. The previous
+                    // implementation replaced the layer array reference, which
+                    // left the old array (still referenced by mainGame.layers)
+                    // untouched. This caused layers to grow with inactive
+                    // sprites. Splicing ensures the shared layer array is
+                    // mutated in place.
+                    const idx = s.layer.indexOf(s);
+                    if (idx !== -1) {
+                        s.layer.splice(idx, 1);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure sprites are properly removed from their rendering layer when marked inactive

## Testing
- `tsc`


------
https://chatgpt.com/codex/tasks/task_e_684e009c8120833094fa2b2c34c5e5f0