### PR TITLE
Fix comment in game loop

### DIFF
--- a/kandy_jump.ts
+++ b/kandy_jump.ts
@@ -137,8 +137,8 @@ class MainGame {
         var nextSprites = [];
         // The updates inside this loop may add to allSprites,
         // so the choice to continue the loop until the very end of
-        // allSprites.size() is in fact critical; otherwise they
-        // won't make it into next_sprites.
+        // allSprites.length is in fact critical; otherwise they
+        // won't make it into nextSprites.
         // In other words, changing this to forEach will cause a
         // problem.
         if (this.allSprites) {


### PR DESCRIPTION
## Summary
- correct references to `allSprites.length` and `nextSprites` inside cycle loop comment

## Testing
- `tsc`


------
https://chatgpt.com/codex/tasks/task_e_684e03329b84833083b510012d8ee827