### PR TITLE
Add rectangle intersection tests

### DIFF
--- a/kandy_jump.ts
+++ b/kandy_jump.ts
@@ -6,7 +6,7 @@ function text_height(text_box: TextMetrics): number {
     return text_box.actualBoundingBoxAscent + text_box.actualBoundingBoxDescent;
 }
 
-class Rectangle {
+export class Rectangle {
     constructor(
         public left: number,
         public top: number,
@@ -18,7 +18,7 @@ class Rectangle {
 }
 // From:
 // https://stackoverflow.com/questions/2752349/fast-rectangle-to-rectangle-intersection#2752387
-function rectanglesIntersect(r1: Rectangle, r2: Rectangle): boolean {
+export function rectanglesIntersect(r1: Rectangle, r2: Rectangle): boolean {
     return !(r2.left > r1.right || 
              r2.right < r1.left || 
              r2.top > r1.bottom ||

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "kandy_jump",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node out/tests/rectangle.test.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/tests/rectangle.test.ts
+++ b/tests/rectangle.test.ts
@@ -1,0 +1,13 @@
+declare function require(path: string): any;
+const assert = require('assert');
+import { Rectangle, rectanglesIntersect } from '../kandy_jump';
+
+const r1 = new Rectangle(0, 0, 10, 10);
+const r2 = new Rectangle(5, 5, 10, 10);
+assert.strictEqual(rectanglesIntersect(r1, r2), true, 'overlapping rectangles should intersect');
+
+const r3 = new Rectangle(20, 20, 5, 5);
+assert.strictEqual(rectanglesIntersect(r1, r3), false, 'non-overlapping rectangles should not intersect');
+
+console.log('rectangle tests passed');
+


### PR DESCRIPTION
## Summary
- export `Rectangle` and `rectanglesIntersect` for external use
- add basic TypeScript test verifying intersection logic
- add `package.json` with build and test scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e03f25e4883309e79bd6a97961d0a